### PR TITLE
[WIP] Remove HCA references from top-level files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ test: lint install integrationtests unittests
 
 
 unittests:
-	coverage run -p --source=hca -m unittest discover -v -t . -s test/unit
+	coverage run -p --source=dss -m unittest discover -v -t . -s test/unit
 
 unit: lint install unittests
 	coverage combine
@@ -18,8 +18,8 @@ unit: lint install unittests
 
 integrationtests:
     # https://github.com/HumanCellAtlas/dcp-cli/issues/127
-	coverage run -p --source=hca -m unittest discover -v -t . -s test/integration/upload
-	coverage run -p --source=hca -m unittest discover -v -t . -s test/integration/dss
+	coverage run -p --source=dss -m unittest discover -v -t . -s test/integration/upload
+	coverage run -p --source=dss -m unittest discover -v -t . -s test/integration/dss
 
 integration: lint install integrationtests
 	coverage combine
@@ -28,9 +28,9 @@ integration: lint install integrationtests
 lint:
 	python ./setup.py flake8
 
-version: hca/version.py
+version: dss/version.py
 
-hca/version.py: setup.py
+dss/version.py: setup.py
 	echo "__version__ = '$$(python setup.py --version)'" > $@
 
 build: version

--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,9 @@
-HCA CLI
+DSS CLI
 =======
 This repository is a pip installable Command Line Interface (CLI) and Python library (API) for interacting with the
-Data Coordination Platform (DCP) of the Human Cell Atlas (HCA).
+Data Storage System (DSS).
 
-Currently the `hca` package supports interaction with the `Upload Service <https://github.com/HumanCellAtlas/upload-service>`_ and `Data Storage Service (DSS) <https://github.com/HumanCellAtlas/data-store>`_ for services such as uploading, downloading,
-and querying data.
-
-The HCA CLI is compatible with Python versions 3.5+ (we are no longer compatible with Python 2.7, and our last compatible Python 2.7 version was `hca==6.4.0`).
+The DSS CLI is compatible with Python versions 3.5+.
 
 Installation
 ------------
@@ -31,32 +28,32 @@ Example CLI/API usage:
 
 * `Python API examples (restricted endpoints) <https://github.com/HumanCellAtlas/dcp-cli/tree/master/docs/OpenAPIExamples.rst>`_
 
-To see the list of commands you can use, type :code:`hca --help`.
+To see the list of commands you can use, type :code:`dss --help`.
 
 Configuration management
 ~~~~~~~~~~~~~~~~~~~~~~~~
-The HCA CLI supports ingesting configuration from a configurable array of sources. Each source is a JSON file.
+The DSS CLI supports ingesting configuration from a configurable array of sources. Each source is a JSON file.
 Configuration sources that follow the first source update the configuration using recursive dictionary merging. Sources
 are enumerated in the following order (i.e., in order of increasing priority):
 
-- Site-wide configuration source, ``/etc/hca/config.json``
-- User configuration source, ``~/.config/hca/config.json``
-- Any sources listed in the colon-delimited variable ``HCA_CONFIG_FILE``
+- Site-wide configuration source, ``/etc/dss/config.json``
+- User configuration source, ``~/.config/dss/config.json``
+- Any sources listed in the colon-delimited variable ``DSS_CLI_CONFIG_FILE``
 - Command line options
 
-**Array merge operators**: When loading a chain of configuration sources, the HCA CLI uses recursive dictionary merging
+**Array merge operators**: When loading a chain of configuration sources, the DSS CLI uses recursive dictionary merging
 to combine the sources. Additionally, when the original config value is a list, the package supports array manipulation
 operators, which let you extend and modify arrays defined in underlying configurations. See
 https://github.com/kislyuk/tweak#array-merge-operators for a list of these operators.
 
 Service to Service Authorization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Google service credentials must be whitelisted before they will authenticate with the HCA CLI.
+Google service credentials must be whitelisted before they will authenticate with the DSS CLI.
 
 Set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to the path of your Google service credentials file to
 authenticate.
 
-One can also use: ``hca dss login``.
+One can also use: ``dss login``.
 
 See `Google service credentials <https://cloud.google.com/iam/docs/understanding-service-accounts>`_ 
 for more information about service accounts. Use the `Google Cloud IAM web console
@@ -65,13 +62,13 @@ for more information about service accounts. Use the `Google Cloud IAM web conso
 Development
 -----------
 To develop on the CLI, first run ``pip install -r requirements-dev.txt``. You can install your locally modified copy of 
-the hca package by running ``make install`` in the repository root directory.
+the DSS CLI package by running ``make install`` in the repository root directory.
 
-To use the command line interface with a local or test DSS, first run ``hca`` (or ``scripts/hca`` if you want to use the
-package in-place from the repository root directory). This will create the file ``~/.config/hca/config.json``, which you
+To use the command line interface with a local or test DSS, first run ``dss`` (or ``scripts/dss`` if you want to use the
+package in-place from the repository root directory). This will create the file ``~/.config/dss/config.json``, which you
 can modify to update the value of ``DSSClient.swagger_url`` to point to the URL of the Swagger definition served by your
 DSS deployment. Lastly, the CLI enforces HTTPS connection to the DSS API. If you are connecting to a local DSS, make
-this change in ``dcp-cli/hca/util/__init__.py`` in the ``SwaggerClient`` object::
+this change in ``dcp-cli/dss/util/__init__.py`` in the ``SwaggerClient`` object::
 
     scheme = "http"
 
@@ -80,48 +77,33 @@ constructor via the ``swagger_url`` parameter::
 
     client = DSSClient(swagger_url="https://dss.example.com/v1/swagger.json")
 
-You can also layer a minimal config file on top of the default ``config.json`` using the ``HCA_CONFIG_FILE`` environment
+You can also layer a minimal config file on top of the default ``config.json`` using the ``DSS_CLI_CONFIG_FILE`` environment
 variable, for example::
 
     export SWAGGER_URL="https://dss.staging.data.humancellatlas.org/v1/swagger.json"
-    jq -n .DSSClient.swagger_url=env.SWAGGER_URL > ~/.config/hca/config.staging.json
-    export HCA_CONFIG_FILE=~/.config/hca/config.staging.json
+    jq -n .DSSClient.swagger_url=env.SWAGGER_URL > ~/.config/dss/config.staging.json
+    export DSS_CLI_CONFIG_FILE=~/.config/dss/config.staging.json
 
 Testing
 -------
-Before you run tests, first run ``hca dss login``.  This will open a browser where you can log in to authenticate
-with Google. Use an email address from one of the whitelisted domains (in ``DSS_SUBSCRIPTION_AUTHORIZED_DOMAINS_ARRAY``
+Before you run tests, first run ``dss login``.  This will open a browser where you can log in to authenticate
+with Google. Use an email address from one of the whitelisted domains (in ``DSS_AUTHORIZED_DOMAINS`` array
 from `here <https://github.com/HumanCellAtlas/data-store/blob/master/environment#L55>`_).
 
 Then :code:`make test`.
 
-Primary CI testing is through Travis CI; there is also additional testing with the
-`Gitlab Allspark instance <https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp-cli/>`_ that runs tests for Windows.
-(Note that Allspark is not open to the public, members of the Human Cell Atlas project can access the Allspark cluster using the Github account
-associated with the Human Cell Atlas organization on Github.) If submitting PRs that have the potential of being platform-dependent, please ensure 
-the status of "Windows Testing" is verified before merging.
+Primary CI testing is through Travis CI.
 
 Bugs
 ~~~~
 Please report bugs, issues, feature requests, etc. in the 
-`HumanCellAtlas/dcp-cli repository on GitHub <https://github.com/HumanCellAtlas/dcp-cli/issues>`_.
-
+`DataBiosphere/data-store-cli repository on GitHub <https://github.com/DataBiosphere/data-store-cli/issues>`_.
 
 Security Policy
 ---------------
-See our `Security Policy <https://github.com/HumanCellAtlas/.github/blob/master/SECURITY.md>`_.
+Security policy: TBA
 
 License
 -------
 Licensed under the terms of the `MIT License <https://opensource.org/licenses/MIT>`_.
 
-.. image:: https://img.shields.io/travis/HumanCellAtlas/dcp-cli.svg?branch=master
-        :target: https://travis-ci.org/HumanCellAtlas/dcp-cli?branch=master
-.. image:: https://codecov.io/github/HumanCellAtlas/dcp-cli/coverage.svg?branch=master
-        :target: https://codecov.io/github/HumanCellAtlas/dcp-cli?branch=master
-.. image:: https://img.shields.io/pypi/v/hca.svg
-        :target: https://pypi.python.org/pypi/hca
-.. image:: https://img.shields.io/pypi/l/hca.svg
-        :target: https://pypi.python.org/pypi/hca
-.. image:: https://readthedocs.org/projects/hca/badge/?version=latest
-        :target: https://hca.readthedocs.io/

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ The DSS CLI is compatible with Python versions 3.5+.
 
 Installation
 ------------
-:code:`pip install hca`.
+:code:`pip install dss`.
 
 Usage
 -----

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(
 setup(
     name="hca",
     version='7.0.0',
-    url='https://github.com/HumanCellAtlas/dcp-cli',
+    url='https://github.com/DataBiosphere/data-store-cli',
     license='Apache Software License',
-    author='Human Cell Atlas contributors',
+    author='Data Store Contributors',
     author_email='akislyuk@chanzuckerberg.com',
-    description='Human Cell Atlas Data Storage System Command Line Interface',
+    description='Data Storage System Command Line Interface',
     long_description=open('README.rst').read(),
     install_requires=install_requires,
     extras_require={
@@ -24,11 +24,11 @@ setup(
     packages=find_packages(exclude=['test']),
     entry_points={
         'console_scripts': [
-            'hca=hca.cli:main'
+            'dss=dss.cli:main'
         ],
     },
     platforms=['MacOS X', 'Posix'],
-    package_data={'hcacli': ['*.json']},
+    package_data={'dsscli': ['*.json']},
     zip_safe=False,
     include_package_data=True,
     test_suite='test',


### PR DESCRIPTION
This series of PRs removes references to HCA/Human Cell Atlas from the codebase.

This PR is the first in the series. It removes references to HCA from top-level files (readme, setup.py, makefile, etc.)

Other things that need to change:
- environment variable names

Things that need to be figured out:
- the `dss` submodule (previously `hca.dss`) now has an awkward name `dss.dss` and a docstring/description that is now redundant, need to figure out how to deal with this submodule
- how to specify "authors"/"author_email" fields in setup.py
- where (domain) to put swagger and documentation
- group and email fields of JWT were changed, need to determine if/how those affect downstream components
- what to name the metadata fields that were previously `hca-dss-{s3,sha1,sha256,crc32c}` (changed from `hca-dss` to `dss-cli`)
- what to do about references to HumanCellAtlas/dcplib