### PR TITLE
[Remove HCA - Part 3] Rename cloud upload metadata key names

### DIFF
--- a/dbio/config.py
+++ b/dbio/config.py
@@ -9,7 +9,7 @@ class DataBiosphereConfig(_Config):
     default_config_file = os.path.join(os.path.dirname(__file__), "default_config.json")
 
     def __init__(self, *args, **kwargs):
-        super(DataBiosphereConfig, self).__init__(name="dss", *args, **kwargs)
+        super(DataBiosphereConfig, self).__init__(name="dbio", *args, **kwargs)
 
     @property
     def config_files(self):

--- a/dbio/dss/upload_to_cloud.py
+++ b/dbio/dss/upload_to_cloud.py
@@ -103,10 +103,10 @@ def upload_to_cloud(file_handles, staging_bucket, replica, from_cloud=False, log
                 )
                 sums = fh.get_checksums()
                 metadata = {
-                    "dbio-dss-s3_etag": sums["s3_etag"],
-                    "dbio-dss-sha1": sums["sha1"],
-                    "dbio-dss-sha256": sums["sha256"],
-                    "dbio-dss-crc32c": sums["crc32c"],
+                    "dss-s3_etag": sums["s3_etag"],
+                    "dss-sha1": sums["sha1"],
+                    "dss-sha256": sums["sha256"],
+                    "dss-crc32c": sums["crc32c"],
                 }
                 s3.meta.client.put_object_tagging(Bucket=destination_bucket.name,
                                                   Key=key_name,

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import uuid
 import unittest
-from fnmatch import fnmatcdbiose
+from fnmatch import fnmatchcase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa


### PR DESCRIPTION
This renames cloud upload metadata key names to match the changes to metadata key names in DataBiosphere/data-store 

* "dss-s3_etag"
* "dss-sha1"
* "dss-sha256"
* "dss-crc32c"

(Note that these labels were changed from the hca prefix, e.g., `hca-dss-sha1`, to the dbio prefix, `dbio-dss-sha1`, in an earlier PR. This PR gets rid of the prefix altogether.)

Related issue: DataBiosphere/data-store#44

Related data-store PR: DataBiosphere/data-store#45
