### PR TITLE
[Remove HCA - Part 4] Rename config directory

### DIFF
--- a/dbio/config.py
+++ b/dbio/config.py
@@ -9,7 +9,7 @@ class DataBiosphereConfig(_Config):
     default_config_file = os.path.join(os.path.dirname(__file__), "default_config.json")
 
     def __init__(self, *args, **kwargs):
-        super(DataBiosphereConfig, self).__init__(name="dss", *args, **kwargs)
+        super(DataBiosphereConfig, self).__init__(name="dbio", *args, **kwargs)
 
     @property
     def config_files(self):

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -11,7 +11,7 @@ import sys
 import tempfile
 import uuid
 import unittest
-from fnmatch import fnmatcdbiose
+from fnmatch import fnmatchcase
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa


### PR DESCRIPTION
Rename config directory from `dss` to `dbio`

This change was requested in an earlier code review for #13 ([link to code review comment](https://github.com/DataBiosphere/data-store-cli/pull/13#discussion_r373653845))

