### PR TITLE
Check to make sure CLI test bucket exists before doing integration test

### DIFF
--- a/dbio/dss/util/__init__.py
+++ b/dbio/dss/util/__init__.py
@@ -2,6 +2,7 @@ import errno
 import logging
 import os
 import shutil
+import boto3
 from builtins import FileExistsError
 
 import atomicwrites
@@ -11,11 +12,14 @@ from ...util.compat import scandir
 log = logging.getLogger(__name__)
 
 
-def check_s3_bucket_exists(bucket_name):
+def check_s3_bucket_exists(bucket_name: str) -> bool:
+    """Check if the specified S3 bucket exists"""
     s3 = boto3.resource('s3')
     destination_bucket = s3.Bucket(bucket_name)
-    err_msg = f"Error: S3 bucket {bucket_name} does not exist!"
-    self.assertFalse(destination_bucket.creation_date is None), err_msg
+    if destination_bucket.creation_date is None:
+        return False
+    else:
+        return True
 
 
 def separator_to_camel_case(separated, separator):

--- a/dbio/dss/util/__init__.py
+++ b/dbio/dss/util/__init__.py
@@ -11,6 +11,13 @@ from ...util.compat import scandir
 log = logging.getLogger(__name__)
 
 
+def check_s3_bucket_exists(bucket_name):
+    s3 = boto3.resource('s3')
+    destination_bucket = s3.Bucket(bucket_name)
+    err_msg = f"Error: S3 bucket {bucket_name} does not exist!"
+    self.assertFalse(destination_bucket.creation_date is None), err_msg
+
+
 def separator_to_camel_case(separated, separator):
     components = separated.split(separator)
     return "".join(x.title() for x in components)

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -12,12 +12,13 @@ import tempfile
 import uuid
 import unittest
 from fnmatch import fnmatchcase
+import boto3
 
 pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))  # noqa
 sys.path.insert(0, pkg_root)  # noqa
 
 import dbio.dss
-from dbio.dss.util import iter_paths, object_name_builder
+from dbio.dss.util import iter_paths, object_name_builder, check_s3_bucket_exists
 from test import reset_tweak_changes, TEST_DIR
 
 
@@ -27,6 +28,7 @@ class TestDssApi(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = dbio.dss.DSSClient()
+        check_s3_bucket_exists(self.staging_bucket)
 
     def test_set_host(self):
         with tempfile.TemporaryDirectory() as home:

--- a/test/integration/dss/test_dss_api.py
+++ b/test/integration/dss/test_dss_api.py
@@ -28,7 +28,7 @@ class TestDssApi(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.client = dbio.dss.DSSClient()
-        check_s3_bucket_exists(self.staging_bucket)
+        self.assertTrue(check_s3_bucket_exists(self.staging_bucket))
 
     def test_set_host(self):
         with tempfile.TemporaryDirectory() as home:

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -29,7 +29,7 @@ class TestDssCLI(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        check_s3_bucket_exists(self.staging_bucket)
+        self.assertTrue(check_s3_bucket_exists(self.staging_bucket))
 
     def test_post_search_cli(self):
         query = json.dumps({})

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -20,11 +20,16 @@ import dbio
 import dbio.cli
 import dbio.dss
 import dbio.util.exceptions
+from dbio.dss.util import check_s3_bucket_exists
 from test import CapturingIO, reset_tweak_changes, TEST_DIR
 
 
 class TestDssCLI(unittest.TestCase):
     staging_bucket = "ucsc-cgp-dss-cli-test"
+
+    @classmethod
+    def setUpClass(cls):
+        check_s3_bucket_exists(self.staging_bucket)
 
     def test_post_search_cli(self):
         query = json.dumps({})

--- a/test/integration/dss/test_dss_cli.py
+++ b/test/integration/dss/test_dss_cli.py
@@ -24,6 +24,8 @@ from test import CapturingIO, reset_tweak_changes, TEST_DIR
 
 
 class TestDssCLI(unittest.TestCase):
+    staging_bucket = "ucsc-cgp-dss-cli-test"
+
     def test_post_search_cli(self):
         query = json.dumps({})
         replica = "aws"
@@ -122,7 +124,7 @@ class TestDssCLI(unittest.TestCase):
     def test_upload_progress_bar(self):
         dirpath = os.path.join(TEST_DIR, 'tutorial', 'data')  # arbitrary and small
         put_args = ['dss', 'upload', '--src-dir', dirpath, '--replica',
-                    'aws', '--staging-bucket', 'ucsc-cgp-dss-cli-test']
+                    'aws', '--staging-bucket', self.staging_bucket]
 
         with self.subTest("Suppress progress bar if not interactive"):
             with CapturingIO('stdout') as stdout:
@@ -138,7 +140,7 @@ class TestDssCLI(unittest.TestCase):
         import pty  # Trying to import this on Windows will cause a ModuleNotFoundError
         dirpath = os.path.join(TEST_DIR, 'tutorial', 'data')  # arbitrary and small
         put_args = ['dss', 'upload', '--src-dir', dirpath, '--replica',
-                    'aws', '--staging-bucket', 'ucsc-cgp-dss-cli-test']
+                    'aws', '--staging-bucket', self.staging_bucket]
 
         # In an interactive session, we should see a progress bar if we
         # don't pass `--no-progress`.
@@ -188,7 +190,7 @@ class TestDssCLI(unittest.TestCase):
     @contextlib.contextmanager
     def _put_test_bdl(dirpath=os.path.join(TEST_DIR, 'res', 'bundle'),
                       replica='aws',
-                      staging_bucket='ucsc-cgp-dss-cli-test'):
+                      staging_bucket=self.staging_bucket):
         """
         Implements a context manager that uploads a bundle to the data
         store using `dbio dss upload` then deletes it when done, if the


### PR DESCRIPTION
This PR adds a check to make sure the CLI test bucket exists before doing integration tests, and also parameterizes the test bucket name

Closes #21 