### PR TITLE
Make windows tests manually triggered

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,6 +48,7 @@ stages:
     - (Get-Content .\hca\default_config.json).replace('dss.data.humancellatlas.org',"dss.${DSS_TEST_STAGE}.data.humancellatlas.org")| Set-Content  .\hca\default_config.json
   script:
     - make test-win
+  when: manual
 
 test-3.5:
   extends: .linux-test-base


### PR DESCRIPTION
Requires that windows tests of the DSS CLI in Gitlab be manually triggered. This saves us some extra overhead.