### PR TITLE
Update secrets store name in .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 variables:
   AWS_DEFAULT_REGION: "us-east-1"
-  DSS_SECRETS_STORE: "dcp/dss"
+  DSS_SECRETS_STORE: "ucsc-cgp/dss"
   DSS_TEST_STAGE: "dev"
   BOTO_CONFIG: "/dev/null"
 


### PR DESCRIPTION
Update secrets store name to `ucsc-cgp/dss` instead of `dcp/dss` so we can fetch secrets during gitlab testing