### PR TITLE
Remove HCA config file reference from .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,7 +27,6 @@ stages:
     - pip install -r requirements-dev.txt
     - scripts/fetch_secret.sh gcp-credentials.json > gcp-credentials.json
     - export GOOGLE_APPLICATION_CREDENTIALS=$(pwd -P)/gcp-credentials.json
-    - sed -i -e s/dss.data.humancellatlas.org/dss.$DSS_TEST_STAGE.data.humancellatlas.org/ hca/default_config.json
   script:
     - make test
   except:
@@ -45,7 +44,6 @@ stages:
     - pip install -r requirements-dev.txt
     - python .\scripts\fetch_secret.py --secret-name gcp-credentials.json --write
     - $env:GOOGLE_APPLICATION_CREDENTIALS = (Convert-Path .\gcp-credentials.json)
-    - (Get-Content .\hca\default_config.json).replace('dss.data.humancellatlas.org',"dss.${DSS_TEST_STAGE}.data.humancellatlas.org")| Set-Content  .\hca\default_config.json
   script:
     - make test-win
   when: manual


### PR DESCRIPTION
This removes a deprecated config file location `hca/default_config.json` and commands that were intended to find/replace humancellatlas URLs from the config file