### PR TITLE
Add a readthedocs config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+
+# Optionally set the requirements required to build your docs
+python:
+  install:
+    - requirements: requirements-dev.txt


### PR DESCRIPTION
We are trying to get the CLI tool's documentation up on readthedocs. We are asking readthedocs to build the dbio CLI tool package, in addition to building the documentation, so that the module's API can be documented.

To do that, readthedocs first runs `pip install -r requirements.txt` then runs `python setup.py build install`.

The problem is, Sphinx dependencies are specified in `requirements-dev.txt` and not in `requirements.txt`

This pull request modifies the Python setup step to use `requirements-dev.txt` instead of the default `requirements.txt`

Part of issue #49 