### PR TITLE
Minor fixes for cutting PyPI releases - update Makefile, common.mk, setup.py

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -22,7 +22,7 @@ release:
 	@if ! which twine; then echo "Twine is required. Please run pip install twine"; exit 1; fi
 	$(eval REMOTE=$(shell git remote get-url origin | cut -f 2 -d : | sed -e s://github.com/:: -e s:.git::))
 	$(eval GIT_USER=$(shell git config --get user.email))
-	$(eval GH_AUTH=$(shell if grep -q '@github.com' ~/.git-credentials; then echo $$(grep '@github.com' ~/.git-credentials | python3 -c 'import sys, urllib.parse as p; print(p.urlparse(sys.stdin.read()).netloc.split("@")[0])'); else echo $(GIT_USER); fi))
+	$(eval GH_AUTH=$(shell if test -f ~/.git-credentials && grep -q '@github.com' ~/.git-credentials; then echo $$(grep '@github.com' ~/.git-credentials | python3 -c 'import sys, urllib.parse as p; print(p.urlparse(sys.stdin.read()).netloc.split("@")[0])'); else echo $(GIT_USER); fi))
 	$(eval RELEASES_API=https://api.github.com/repos/${REMOTE}/releases)
 	$(eval UPLOADS_API=https://uploads.github.com/repos/${REMOTE}/releases)
 	git pull

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url='https://github.com/DataBiosphere/data-store-cli',
     license='MIT License',
     author='University of California Santa Cruz',
-    author_email='akislyuk@chanzuckerberg.com',
+    author_email='team-redwood@ucsc.edu',
     description='Data Biosphere Data Store Command Line Interface',
     long_description=open('README.rst').read(),
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 install_requires = [line.rstrip() for line in open(os.path.join(os.path.dirname(__file__), "requirements.txt"))]
 
 setup(
-    name="dbio",
+    name="dbio-cli",
     version='7.0.0',
     url='https://github.com/DataBiosphere/data-store-cli',
     license='MIT License',


### PR DESCRIPTION
Make modifications to setup.py and release rule in Makefile to prepare for a PyPI release.

- update make release rule to check if file exists before grepping in said file
- update author email
- update version number to 7.0.0