### PR TITLE
[EASY] Add method to get Auth0 token claim from swagger

### DIFF
--- a/dbio/util/__init__.py
+++ b/dbio/util/__init__.py
@@ -286,6 +286,11 @@ class SwaggerClient(object):
         return _deep_get(self.swagger_spec, ['securityDefinitions', 'OauthSecurity', 'x-group-claim']) or \
             urljoin(self._audience(), 'group')
 
+    @property
+    def auth0_claim(self):
+        return _deep_get(self.swagger_spec, ['securityDefinitions', 'OauthSecurity', 'x-auth0-claim']) or \
+            urljoin(self._audience(), 'auth0')
+
     @staticmethod
     def load_swagger_json(swagger_json, ptr_str="$ref"):
         """


### PR DESCRIPTION
This adds a method to get the Auth0 token claim from the DSS swagger file.

Relies on DataBiosphere/data-store#143 (add auth0 token claim to swagger security definitions).

Related to #43 (make OIDC layer in CLI tool more flexible)